### PR TITLE
add Makefile and udeps check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
           override: true
 
       - name: Run rust-clippy
-        run: cargo clippy --all-targets --all-features -- -D warnings
+        run: make check-clippy
 
   fmt:
     name: Run rustfmt
@@ -43,7 +43,29 @@ jobs:
           override: true
 
       - name: Run rustfmt
-        run: cargo fmt --all -- --check
+        run: make check-fmt
+
+  udeps:
+    name: Run udeps
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af #@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          override: true
+      
+
+      - name: Install cargo-udeps
+        run: cargo install cargo-udeps --locked
+
+      - name: Run udeps
+        run: make check-udeps
 
   test:
     name: Run Tests
@@ -54,4 +76,4 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Tests
-        run: cargo test --all
+        run: make test

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,52 @@
+# -------------------------
+# Rust CI Makefile
+# -------------------------
+
+RUST_TOOLCHAIN_STABLE := stable
+RUST_TOOLCHAIN_CLIPPY := 1.81.0
+
+# Default target
+.PHONY: all
+all: check-fmt check-clippy check-udeps test
+
+# -------------------------
+# Format checking
+# -------------------------
+.PHONY: check-fmt
+check-fmt: ## Check Rust formatting
+	rustup run $(RUST_TOOLCHAIN_STABLE) cargo fmt --all -- --check
+
+# -------------------------
+# Clippy linting
+# -------------------------
+.PHONY: check-clippy
+check-clippy: ## Run Clippy linter
+	rustup run $(RUST_TOOLCHAIN_CLIPPY) cargo clippy --all-targets --all-features -- -D warnings
+
+# -------------------------
+# Unused dependencies check
+# -------------------------
+.PHONY: check-udeps
+check-udeps: ## Check for unused dependencies
+	cargo +nightly udeps --workspace --all-targets
+
+# -------------------------
+# Build project
+# -------------------------
+.PHONY: build
+build: ## Build Rust project
+	cargo build --all
+
+# -------------------------
+# Run tests
+# -------------------------
+.PHONY: test
+test: ## Run all tests
+	cargo test --all
+
+# -------------------------
+# Clean project
+# -------------------------
+.PHONY: clean
+clean: ## Remove target directory
+	cargo clean


### PR DESCRIPTION
## Summary

This pull request updates the **CI workflow**  to use a `Makefile` for key Rust project tasks.  
It replaces direct `cargo` commands in the GitHub Actions workflow with corresponding `make` targets, ensuring a single source of truth for common development and CI operations.

## Changes

- **Introduced a `Makefile`** to centralize key tasks:
  - Code formatting (`cargo fmt`)
  - Linting with Clippy (`cargo clippy`)
  - Unused dependency checks (`cargo udeps`)
  - Running tests (`cargo test`)
- **Updated CI workflow** to:
  - Replace direct `cargo` calls with `make` targets.
  - Improve maintainability and consistency between CI and local development.
